### PR TITLE
Estratégias de módulos

### DIFF
--- a/desafio.xcodeproj/project.pbxproj
+++ b/desafio.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		6C58CCA32625FF0D001F7524 /* desafioUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C58CCA22625FF0D001F7524 /* desafioUITests.swift */; };
 		6C58CCBD26260262001F7524 /* AdListViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C58CCBC26260262001F7524 /* AdListViewLayout.swift */; };
 		6C58CCD226261245001F7524 /* Ad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C58CCD126261245001F7524 /* Ad.swift */; };
+		77B2675326878DED00B078B2 /* ONetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2674C26878DA400B078B2 /* ONetwork.framework */; };
+		77B2675426878DED00B078B2 /* ONetwork.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2674C26878DA400B078B2 /* ONetwork.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		77B2679326878F1500B078B2 /* OUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2678D26878E9A00B078B2 /* OUIKit.framework */; };
+		77B2679426878F1500B078B2 /* OUIKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2678D26878E9A00B078B2 /* OUIKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,7 +44,50 @@
 			remoteGlobalIDString = 6C58CC7C2625FF09001F7524;
 			remoteInfo = desafio;
 		};
+		77B2674B26878DA400B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B2674426878DA300B078B2 /* ONetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77B2672A26878DA200B078B2;
+			remoteInfo = ONetwork;
+		};
+		77B2674D26878DA400B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B2674426878DA300B078B2 /* ONetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77B2673326878DA300B078B2;
+			remoteInfo = ONetworkTests;
+		};
+		77B2678C26878E9A00B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B2678526878E9900B078B2 /* OUIKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77B2676B26878E9900B078B2;
+			remoteInfo = OUIKit;
+		};
+		77B2678E26878E9A00B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B2678526878E9900B078B2 /* OUIKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77B2677426878E9900B078B2;
+			remoteInfo = OUIKitTests;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		77B2675526878DED00B078B2 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				77B2675426878DED00B078B2 /* ONetwork.framework in Embed Frameworks */,
+				77B2679426878F1500B078B2 /* OUIKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		6C19D333262F127B00068196 /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
@@ -65,6 +112,8 @@
 		6C58CCA42625FF0D001F7524 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6C58CCBC26260262001F7524 /* AdListViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdListViewLayout.swift; sourceTree = "<group>"; };
 		6C58CCD126261245001F7524 /* Ad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ad.swift; sourceTree = "<group>"; };
+		77B2674426878DA300B078B2 /* ONetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ONetwork.xcodeproj; path = modules/ONetwork/ONetwork.xcodeproj; sourceTree = "<group>"; };
+		77B2678526878E9900B078B2 /* OUIKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OUIKit.xcodeproj; path = modules/OUIKit/OUIKit.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +121,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				77B2675326878DED00B078B2 /* ONetwork.framework in Frameworks */,
+				77B2679326878F1500B078B2 /* OUIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,10 +146,14 @@
 		6C58CC742625FF09001F7524 = {
 			isa = PBXGroup;
 			children = (
+				77B2679226878EF200B078B2 /* UFeatures */,
+				77B2678526878E9900B078B2 /* OUIKit.xcodeproj */,
+				77B2674426878DA300B078B2 /* ONetwork.xcodeproj */,
 				6C58CC7F2625FF09001F7524 /* desafio */,
 				6C58CC962625FF0D001F7524 /* desafioTests */,
 				6C58CCA12625FF0D001F7524 /* desafioUITests */,
 				6C58CC7E2625FF09001F7524 /* Products */,
+				77B2675226878DED00B078B2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -160,6 +215,38 @@
 			path = UI;
 			sourceTree = "<group>";
 		};
+		77B2674526878DA300B078B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				77B2674C26878DA400B078B2 /* ONetwork.framework */,
+				77B2674E26878DA400B078B2 /* ONetworkTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		77B2675226878DED00B078B2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		77B2678626878E9900B078B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				77B2678D26878E9A00B078B2 /* OUIKit.framework */,
+				77B2678F26878E9A00B078B2 /* OUIKitTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		77B2679226878EF200B078B2 /* UFeatures */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = UFeatures;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -170,6 +257,7 @@
 				6C58CC792625FF09001F7524 /* Sources */,
 				6C58CC7A2625FF09001F7524 /* Frameworks */,
 				6C58CC7B2625FF09001F7524 /* Resources */,
+				77B2675526878DED00B078B2 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -249,6 +337,16 @@
 			mainGroup = 6C58CC742625FF09001F7524;
 			productRefGroup = 6C58CC7E2625FF09001F7524 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 77B2674526878DA300B078B2 /* Products */;
+					ProjectRef = 77B2674426878DA300B078B2 /* ONetwork.xcodeproj */;
+				},
+				{
+					ProductGroup = 77B2678626878E9900B078B2 /* Products */;
+					ProjectRef = 77B2678526878E9900B078B2 /* OUIKit.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				6C58CC7C2625FF09001F7524 /* desafio */,
@@ -257,6 +355,37 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		77B2674C26878DA400B078B2 /* ONetwork.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ONetwork.framework;
+			remoteRef = 77B2674B26878DA400B078B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		77B2674E26878DA400B078B2 /* ONetworkTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ONetworkTests.xctest;
+			remoteRef = 77B2674D26878DA400B078B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		77B2678D26878E9A00B078B2 /* OUIKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OUIKit.framework;
+			remoteRef = 77B2678C26878E9A00B078B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		77B2678F26878E9A00B078B2 /* OUIKitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = OUIKitTests.xctest;
+			remoteRef = 77B2678E26878E9A00B078B2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		6C58CC7B2625FF09001F7524 /* Resources */ = {

--- a/desafio/AdsListViewController.swift
+++ b/desafio/AdsListViewController.swift
@@ -6,11 +6,12 @@
 //
 
 import UIKit
+import ONetwork
 
 class AdsListViewController: UIViewController {
 
     // Mark: properties
-
+    
     var ads: [Ad] = []
     lazy private var flowLayout: AdListViewLayout = {
         let layout = AdListViewLayout()

--- a/modules/OCore/OCore/OCore.xcodeproj/project.pbxproj
+++ b/modules/OCore/OCore/OCore.xcodeproj/project.pbxproj
@@ -1,0 +1,458 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		77B26844268791B400B078B2 /* OCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2683A268791B400B078B2 /* OCore.framework */; };
+		77B26849268791B400B078B2 /* OCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B26848268791B400B078B2 /* OCoreTests.swift */; };
+		77B2684B268791B400B078B2 /* OCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 77B2683D268791B400B078B2 /* OCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		77B26845268791B400B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B26831268791B400B078B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 77B26839268791B400B078B2;
+			remoteInfo = OCore;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		77B2683A268791B400B078B2 /* OCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77B2683D268791B400B078B2 /* OCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCore.h; sourceTree = "<group>"; };
+		77B2683E268791B400B078B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77B26843268791B400B078B2 /* OCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		77B26848268791B400B078B2 /* OCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCoreTests.swift; sourceTree = "<group>"; };
+		77B2684A268791B400B078B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		77B26837268791B400B078B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B26840268791B400B078B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B26844268791B400B078B2 /* OCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		77B26830268791B400B078B2 = {
+			isa = PBXGroup;
+			children = (
+				77B2683C268791B400B078B2 /* OCore */,
+				77B26847268791B400B078B2 /* OCoreTests */,
+				77B2683B268791B400B078B2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		77B2683B268791B400B078B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				77B2683A268791B400B078B2 /* OCore.framework */,
+				77B26843268791B400B078B2 /* OCoreTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		77B2683C268791B400B078B2 /* OCore */ = {
+			isa = PBXGroup;
+			children = (
+				77B2683D268791B400B078B2 /* OCore.h */,
+				77B2683E268791B400B078B2 /* Info.plist */,
+			);
+			path = OCore;
+			sourceTree = "<group>";
+		};
+		77B26847268791B400B078B2 /* OCoreTests */ = {
+			isa = PBXGroup;
+			children = (
+				77B26848268791B400B078B2 /* OCoreTests.swift */,
+				77B2684A268791B400B078B2 /* Info.plist */,
+			);
+			path = OCoreTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		77B26835268791B400B078B2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2684B268791B400B078B2 /* OCore.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		77B26839268791B400B078B2 /* OCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77B2684E268791B400B078B2 /* Build configuration list for PBXNativeTarget "OCore" */;
+			buildPhases = (
+				77B26835268791B400B078B2 /* Headers */,
+				77B26836268791B400B078B2 /* Sources */,
+				77B26837268791B400B078B2 /* Frameworks */,
+				77B26838268791B400B078B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OCore;
+			productName = OCore;
+			productReference = 77B2683A268791B400B078B2 /* OCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		77B26842268791B400B078B2 /* OCoreTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77B26851268791B400B078B2 /* Build configuration list for PBXNativeTarget "OCoreTests" */;
+			buildPhases = (
+				77B2683F268791B400B078B2 /* Sources */,
+				77B26840268791B400B078B2 /* Frameworks */,
+				77B26841268791B400B078B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				77B26846268791B400B078B2 /* PBXTargetDependency */,
+			);
+			name = OCoreTests;
+			productName = OCoreTests;
+			productReference = 77B26843268791B400B078B2 /* OCoreTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		77B26831268791B400B078B2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					77B26839268791B400B078B2 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+					77B26842268791B400B078B2 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 77B26834268791B400B078B2 /* Build configuration list for PBXProject "OCore" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 77B26830268791B400B078B2;
+			productRefGroup = 77B2683B268791B400B078B2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				77B26839268791B400B078B2 /* OCore */,
+				77B26842268791B400B078B2 /* OCoreTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		77B26838268791B400B078B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B26841268791B400B078B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		77B26836268791B400B078B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2683F268791B400B078B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B26849268791B400B078B2 /* OCoreTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		77B26846268791B400B078B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 77B26839268791B400B078B2 /* OCore */;
+			targetProxy = 77B26845268791B400B078B2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		77B2684C268791B400B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		77B2684D268791B400B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		77B2684F268791B400B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = OCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.vinicius.OCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		77B26850268791B400B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = OCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.vinicius.OCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		77B26852268791B400B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				INFOPLIST_FILE = OCoreTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.vinicius.OCoreTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		77B26853268791B400B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				INFOPLIST_FILE = OCoreTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.vinicius.OCoreTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		77B26834268791B400B078B2 /* Build configuration list for PBXProject "OCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2684C268791B400B078B2 /* Debug */,
+				77B2684D268791B400B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77B2684E268791B400B078B2 /* Build configuration list for PBXNativeTarget "OCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2684F268791B400B078B2 /* Debug */,
+				77B26850268791B400B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77B26851268791B400B078B2 /* Build configuration list for PBXNativeTarget "OCoreTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B26852268791B400B078B2 /* Debug */,
+				77B26853268791B400B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 77B26831268791B400B078B2 /* Project object */;
+}

--- a/modules/OCore/OCore/OCore/Info.plist
+++ b/modules/OCore/OCore/OCore/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/modules/OCore/OCore/OCore/OCore.h
+++ b/modules/OCore/OCore/OCore/OCore.h
@@ -1,0 +1,18 @@
+//
+//  OCore.h
+//  OCore
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for OCore.
+FOUNDATION_EXPORT double OCoreVersionNumber;
+
+//! Project version string for OCore.
+FOUNDATION_EXPORT const unsigned char OCoreVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <OCore/PublicHeader.h>
+
+

--- a/modules/OCore/OCore/OCoreTests/Info.plist
+++ b/modules/OCore/OCore/OCoreTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/modules/OCore/OCore/OCoreTests/OCoreTests.swift
+++ b/modules/OCore/OCore/OCoreTests/OCoreTests.swift
@@ -1,0 +1,33 @@
+//
+//  OCoreTests.swift
+//  OCoreTests
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+import XCTest
+@testable import OCore
+
+class OCoreTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/modules/ONetwork/ONetwork.xcodeproj/project.pbxproj
+++ b/modules/ONetwork/ONetwork.xcodeproj/project.pbxproj
@@ -1,0 +1,476 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		77B2673426878DA300B078B2 /* ONetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2672A26878DA200B078B2 /* ONetwork.framework */; };
+		77B2673926878DA300B078B2 /* ONetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B2673826878DA300B078B2 /* ONetworkTests.swift */; };
+		77B2673B26878DA300B078B2 /* ONetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 77B2672D26878DA200B078B2 /* ONetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77B2675E26878E1200B078B2 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B2675D26878E1200B078B2 /* Service.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		77B2673526878DA300B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B2672126878DA200B078B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 77B2672926878DA200B078B2;
+			remoteInfo = ONetwork;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		77B2672A26878DA200B078B2 /* ONetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ONetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77B2672D26878DA200B078B2 /* ONetwork.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ONetwork.h; sourceTree = "<group>"; };
+		77B2672E26878DA200B078B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77B2673326878DA300B078B2 /* ONetworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ONetworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		77B2673826878DA300B078B2 /* ONetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ONetworkTests.swift; sourceTree = "<group>"; };
+		77B2673A26878DA300B078B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77B2675D26878E1200B078B2 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		77B2672726878DA200B078B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2673026878DA300B078B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2673426878DA300B078B2 /* ONetwork.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		77B2672026878DA200B078B2 = {
+			isa = PBXGroup;
+			children = (
+				77B2672C26878DA200B078B2 /* ONetwork */,
+				77B2673726878DA300B078B2 /* ONetworkTests */,
+				77B2672B26878DA200B078B2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		77B2672B26878DA200B078B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				77B2672A26878DA200B078B2 /* ONetwork.framework */,
+				77B2673326878DA300B078B2 /* ONetworkTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		77B2672C26878DA200B078B2 /* ONetwork */ = {
+			isa = PBXGroup;
+			children = (
+				77B2675C26878DF700B078B2 /* Service */,
+				77B2672D26878DA200B078B2 /* ONetwork.h */,
+				77B2672E26878DA200B078B2 /* Info.plist */,
+			);
+			path = ONetwork;
+			sourceTree = "<group>";
+		};
+		77B2673726878DA300B078B2 /* ONetworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				77B2673826878DA300B078B2 /* ONetworkTests.swift */,
+				77B2673A26878DA300B078B2 /* Info.plist */,
+			);
+			path = ONetworkTests;
+			sourceTree = "<group>";
+		};
+		77B2675C26878DF700B078B2 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				77B2675D26878E1200B078B2 /* Service.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		77B2672526878DA200B078B2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2673B26878DA300B078B2 /* ONetwork.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		77B2672926878DA200B078B2 /* ONetwork */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77B2673E26878DA300B078B2 /* Build configuration list for PBXNativeTarget "ONetwork" */;
+			buildPhases = (
+				77B2672526878DA200B078B2 /* Headers */,
+				77B2672626878DA200B078B2 /* Sources */,
+				77B2672726878DA200B078B2 /* Frameworks */,
+				77B2672826878DA200B078B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ONetwork;
+			productName = ONetwork;
+			productReference = 77B2672A26878DA200B078B2 /* ONetwork.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		77B2673226878DA300B078B2 /* ONetworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77B2674126878DA300B078B2 /* Build configuration list for PBXNativeTarget "ONetworkTests" */;
+			buildPhases = (
+				77B2672F26878DA300B078B2 /* Sources */,
+				77B2673026878DA300B078B2 /* Frameworks */,
+				77B2673126878DA300B078B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				77B2673626878DA300B078B2 /* PBXTargetDependency */,
+			);
+			name = ONetworkTests;
+			productName = ONetworkTests;
+			productReference = 77B2673326878DA300B078B2 /* ONetworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		77B2672126878DA200B078B2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					77B2672926878DA200B078B2 = {
+						CreatedOnToolsVersion = 12.4;
+						LastSwiftMigration = 1240;
+					};
+					77B2673226878DA300B078B2 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 77B2672426878DA200B078B2 /* Build configuration list for PBXProject "ONetwork" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 77B2672026878DA200B078B2;
+			productRefGroup = 77B2672B26878DA200B078B2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				77B2672926878DA200B078B2 /* ONetwork */,
+				77B2673226878DA300B078B2 /* ONetworkTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		77B2672826878DA200B078B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2673126878DA300B078B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		77B2672626878DA200B078B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2675E26878E1200B078B2 /* Service.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2672F26878DA300B078B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2673926878DA300B078B2 /* ONetworkTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		77B2673626878DA300B078B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 77B2672926878DA200B078B2 /* ONetwork */;
+			targetProxy = 77B2673526878DA300B078B2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		77B2673C26878DA300B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		77B2673D26878DA300B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		77B2673F26878DA300B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ONetwork/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.ONetwork;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		77B2674026878DA300B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ONetwork/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.ONetwork;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		77B2674226878DA300B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				INFOPLIST_FILE = ONetworkTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.ONetworkTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		77B2674326878DA300B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				INFOPLIST_FILE = ONetworkTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.ONetworkTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		77B2672426878DA200B078B2 /* Build configuration list for PBXProject "ONetwork" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2673C26878DA300B078B2 /* Debug */,
+				77B2673D26878DA300B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77B2673E26878DA300B078B2 /* Build configuration list for PBXNativeTarget "ONetwork" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2673F26878DA300B078B2 /* Debug */,
+				77B2674026878DA300B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77B2674126878DA300B078B2 /* Build configuration list for PBXNativeTarget "ONetworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2674226878DA300B078B2 /* Debug */,
+				77B2674326878DA300B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 77B2672126878DA200B078B2 /* Project object */;
+}

--- a/modules/ONetwork/ONetwork/Info.plist
+++ b/modules/ONetwork/ONetwork/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/modules/ONetwork/ONetwork/ONetwork.h
+++ b/modules/ONetwork/ONetwork/ONetwork.h
@@ -1,0 +1,18 @@
+//
+//  ONetwork.h
+//  ONetwork
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for ONetwork.
+FOUNDATION_EXPORT double ONetworkVersionNumber;
+
+//! Project version string for ONetwork.
+FOUNDATION_EXPORT const unsigned char ONetworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ONetwork/PublicHeader.h>
+
+

--- a/modules/ONetwork/ONetwork/Service/Service.swift
+++ b/modules/ONetwork/ONetwork/Service/Service.swift
@@ -1,0 +1,17 @@
+//
+//  Service.swift
+//  ONetwork
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+import Foundation
+
+public struct Provider {
+    
+    public init() {
+        
+    }
+    
+    
+}

--- a/modules/ONetwork/ONetworkTests/Info.plist
+++ b/modules/ONetwork/ONetworkTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/modules/ONetwork/ONetworkTests/ONetworkTests.swift
+++ b/modules/ONetwork/ONetworkTests/ONetworkTests.swift
@@ -1,0 +1,33 @@
+//
+//  ONetworkTests.swift
+//  ONetworkTests
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+import XCTest
+@testable import ONetwork
+
+class ONetworkTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/modules/OUIKit/OUIKit.xcodeproj/project.pbxproj
+++ b/modules/OUIKit/OUIKit.xcodeproj/project.pbxproj
@@ -1,0 +1,458 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		77B2677526878E9900B078B2 /* OUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77B2676B26878E9900B078B2 /* OUIKit.framework */; };
+		77B2677A26878E9900B078B2 /* OUIKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B2677926878E9900B078B2 /* OUIKitTests.swift */; };
+		77B2677C26878E9900B078B2 /* OUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 77B2676E26878E9900B078B2 /* OUIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		77B2677626878E9900B078B2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77B2676226878E9900B078B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 77B2676A26878E9900B078B2;
+			remoteInfo = OUIKit;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		77B2676B26878E9900B078B2 /* OUIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OUIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		77B2676E26878E9900B078B2 /* OUIKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OUIKit.h; sourceTree = "<group>"; };
+		77B2676F26878E9900B078B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77B2677426878E9900B078B2 /* OUIKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OUIKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		77B2677926878E9900B078B2 /* OUIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OUIKitTests.swift; sourceTree = "<group>"; };
+		77B2677B26878E9900B078B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		77B2676826878E9900B078B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2677126878E9900B078B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2677526878E9900B078B2 /* OUIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		77B2676126878E9900B078B2 = {
+			isa = PBXGroup;
+			children = (
+				77B2676D26878E9900B078B2 /* OUIKit */,
+				77B2677826878E9900B078B2 /* OUIKitTests */,
+				77B2676C26878E9900B078B2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		77B2676C26878E9900B078B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				77B2676B26878E9900B078B2 /* OUIKit.framework */,
+				77B2677426878E9900B078B2 /* OUIKitTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		77B2676D26878E9900B078B2 /* OUIKit */ = {
+			isa = PBXGroup;
+			children = (
+				77B2676E26878E9900B078B2 /* OUIKit.h */,
+				77B2676F26878E9900B078B2 /* Info.plist */,
+			);
+			path = OUIKit;
+			sourceTree = "<group>";
+		};
+		77B2677826878E9900B078B2 /* OUIKitTests */ = {
+			isa = PBXGroup;
+			children = (
+				77B2677926878E9900B078B2 /* OUIKitTests.swift */,
+				77B2677B26878E9900B078B2 /* Info.plist */,
+			);
+			path = OUIKitTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		77B2676626878E9900B078B2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2677C26878E9900B078B2 /* OUIKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		77B2676A26878E9900B078B2 /* OUIKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77B2677F26878E9900B078B2 /* Build configuration list for PBXNativeTarget "OUIKit" */;
+			buildPhases = (
+				77B2676626878E9900B078B2 /* Headers */,
+				77B2676726878E9900B078B2 /* Sources */,
+				77B2676826878E9900B078B2 /* Frameworks */,
+				77B2676926878E9900B078B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OUIKit;
+			productName = OUIKit;
+			productReference = 77B2676B26878E9900B078B2 /* OUIKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		77B2677326878E9900B078B2 /* OUIKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77B2678226878E9900B078B2 /* Build configuration list for PBXNativeTarget "OUIKitTests" */;
+			buildPhases = (
+				77B2677026878E9900B078B2 /* Sources */,
+				77B2677126878E9900B078B2 /* Frameworks */,
+				77B2677226878E9900B078B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				77B2677726878E9900B078B2 /* PBXTargetDependency */,
+			);
+			name = OUIKitTests;
+			productName = OUIKitTests;
+			productReference = 77B2677426878E9900B078B2 /* OUIKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		77B2676226878E9900B078B2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					77B2676A26878E9900B078B2 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+					77B2677326878E9900B078B2 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 77B2676526878E9900B078B2 /* Build configuration list for PBXProject "OUIKit" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 77B2676126878E9900B078B2;
+			productRefGroup = 77B2676C26878E9900B078B2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				77B2676A26878E9900B078B2 /* OUIKit */,
+				77B2677326878E9900B078B2 /* OUIKitTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		77B2676926878E9900B078B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2677226878E9900B078B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		77B2676726878E9900B078B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B2677026878E9900B078B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				77B2677A26878E9900B078B2 /* OUIKitTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		77B2677726878E9900B078B2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 77B2676A26878E9900B078B2 /* OUIKit */;
+			targetProxy = 77B2677626878E9900B078B2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		77B2677D26878E9900B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		77B2677E26878E9900B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		77B2678026878E9900B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = OUIKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.OUIKit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		77B2678126878E9900B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = OUIKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.OUIKit;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		77B2678326878E9900B078B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				INFOPLIST_FILE = OUIKitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.OUIKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		77B2678426878E9900B078B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 92KFQZ687A;
+				INFOPLIST_FILE = OUIKitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = br.com.will.OUIKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		77B2676526878E9900B078B2 /* Build configuration list for PBXProject "OUIKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2677D26878E9900B078B2 /* Debug */,
+				77B2677E26878E9900B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77B2677F26878E9900B078B2 /* Build configuration list for PBXNativeTarget "OUIKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2678026878E9900B078B2 /* Debug */,
+				77B2678126878E9900B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		77B2678226878E9900B078B2 /* Build configuration list for PBXNativeTarget "OUIKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77B2678326878E9900B078B2 /* Debug */,
+				77B2678426878E9900B078B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 77B2676226878E9900B078B2 /* Project object */;
+}

--- a/modules/OUIKit/OUIKit/Info.plist
+++ b/modules/OUIKit/OUIKit/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/modules/OUIKit/OUIKit/OUIKit.h
+++ b/modules/OUIKit/OUIKit/OUIKit.h
@@ -1,0 +1,18 @@
+//
+//  OUIKit.h
+//  OUIKit
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for OUIKit.
+FOUNDATION_EXPORT double OUIKitVersionNumber;
+
+//! Project version string for OUIKit.
+FOUNDATION_EXPORT const unsigned char OUIKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <OUIKit/PublicHeader.h>
+
+

--- a/modules/OUIKit/OUIKitTests/Info.plist
+++ b/modules/OUIKit/OUIKitTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/modules/OUIKit/OUIKitTests/OUIKitTests.swift
+++ b/modules/OUIKit/OUIKitTests/OUIKitTests.swift
@@ -1,0 +1,33 @@
+//
+//  OUIKitTests.swift
+//  OUIKitTests
+//
+//  Created by Vinicius Mangueira Correa on 26/06/21.
+//
+
+import XCTest
+@testable import OUIKit
+
+class OUIKitTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
:sparkles: **Estratégias de módulos** :sparkles:
A estratégia de módulo consiste em modularizar o projeto em módulos que nós dão oportunidade de reaproveitar código dentro do monolito
- [x] ONetwork(Módulo com a camada de serviço)
- [x] OUIKit(Módulo com a camada agnóstica de UI)
- [x] OCore(Módulo com a camada agnóstica de foundation) 
